### PR TITLE
17_Rails動画教材ページの実装

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -15,6 +15,10 @@ body {
   padding-top: 56px;
 }
 
+.card-size {
+  height: 80px;
+}
+
 // ログイン画面
 .container-login {
   @extend .container-fluid;

--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -1,0 +1,11 @@
+class MoviesController < ApplicationController
+  PER_PAGE = 12
+
+  def index
+    if params[:genre].present?
+      @movies = Movie.where(genre: params[:genre]).page(params[:page])
+    else
+      @movies = Movie.where(genre: ["Basic", "Git", "HTML&CSS", "Ruby", "Ruby on Rails"]).page(params[:page])
+    end
+  end
+end

--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -1,5 +1,3 @@
 class Movie < ApplicationRecord
-  validates :genre, presence: true
-  validates :title, presence: true
-  validates :url, presence: true
+  validates :genre, :title, :url, presence: true
 end

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -15,7 +15,7 @@
             </a>
             <div class="dropdown-menu" aria-labelledby="navbarDropdown">
               <%= link_to "Ruby/Rails教材", "#", class: "dropdown-item" %>
-              <%= link_to "動画教材", "#", class: "dropdown-item" %>
+              <%= link_to "動画教材", movies_path, class: "dropdown-item" %>
               <%= link_to "AWS講座", "#", class: "dropdown-item" %>
               <%= link_to "プログラミング勉強会", "#", class: "dropdown-item" %>
               <%= link_to "質問集", "#", class: "dropdown-item" %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,7 +13,7 @@
       <%= render partial: "layouts/header" %>
     </header>
     <main>
-    <%= render "layouts/flash" %>
+      <%= render "layouts/flash" %>
       <div class="base-container">
         <%= yield %>
       </div>
@@ -22,4 +22,3 @@
     </footer>
   </body>
 </html>
-  

--- a/app/views/movies/index.html.erb
+++ b/app/views/movies/index.html.erb
@@ -1,0 +1,14 @@
+<div class="row">
+  <% @movies.each do |movie| %>
+    <div class="col-12 col-md-6 col-lg-4">
+      <div class="card border-dark mb-3">
+        <div class="card-header embed-responsive embed-responsive-16by9">
+          <iframe class="embed-responsive-item" src="<%= movie.url %>"  allowfullscreen></iframe>
+        </div>
+        <div class="card-body card-size">
+          <h5 class="card-title" style="font-size: 16px; padding-top: 10px;"><%= movie.title %> </h5>
+        </div>
+      </div>
+    </div>
+  <% end %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,7 @@
 Rails.application.routes.draw do
-  
   devise_for :admin_users, ActiveAdmin::Devise.config
   ActiveAdmin.routes(self)
   devise_for :users
-  root to: "texts#index"
-
+  root "texts#index"
+  resources :movies, only: [:index, :show]
 end


### PR DESCRIPTION
## 実装内容

-　動画教材の一覧ページの実装
  - Movieのコントローラー、モデル、ビュー作成
  - BootstrapのCardsとGrid Systemを用いたデザイン

## 参考資料

(例)
- Bootstrap 公式サイト
  - [Grid System](https://getbootstrap.jp/docs/4.5/layout/grid/)
  - [Cards](https://getbootstrap.jp/docs/4.2/components/card/)

- やんばるCODE
  - [Bootstrap教材（その1）　画面幅](https://arcane-gorge-21903.herokuapp.com/texts/260)
  - [Bootstrap教材（その2）　グリッドシステム](https://arcane-gorge-21903.herokuapp.com/texts/261)

## チェックリスト

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認

## 質問
モデル、ビュー、コントローラーの記載を行いました。
動画一覧ページ自体はページエラーは出ません
URLも(http://localhost:3000/movies)　  までは表示される。
しかし、動画一覧ページが表示されず。
どこかの記載が不足しているのでしょうか。
教えていただけると幸いです。

## 備考
routes.rb　にて
 root to: "texts#index"　がエラー表示となるため、一旦削除させていただきました。
これはroot "texts#index" に変更すればよかったでしょうか。