### PR TITLE
22_テキスト教材一覧カードUIの調整

### DIFF
--- a/app/assets/stylesheets/texts.scss
+++ b/app/assets/stylesheets/texts.scss
@@ -9,11 +9,20 @@ div {
     height: 370px;
     max-width: 376px;
     margin: 0 auto;
+
+    a {
+      text-decoration: none;
+    }
   }
 }
 
 .text-title {
   margin-top: 30px;
+  margin-bottom: 12px;
+}
+
+.text-subtitle {
+  margin-bottom: 12px;
 }
 
 .CodeRay {

--- a/app/views/texts/index.html.erb
+++ b/app/views/texts/index.html.erb
@@ -11,8 +11,8 @@
           </div>
           <div class="card-body text-dark text-card-body">
             <p class="btn btn-primary btn-block">Dummy Button</p>
-            <p class="card-title text-title"><%= text.title %></p>
-            <p class="card-subtitle">【<%= text.genre %>】</p>
+            <p class="text-title"><%= text.title %></p>
+            <p class="text-subtitle">【<%= text.genre %>】</p>
           </div>
         <% end %>
       </div>


### PR DESCRIPTION
## 実装内容

- カードUIの見た目を調整
  - app/assets/stylesheets/texts.scss, app/views/texts/index.html.erb
    - リンクが有効になるクリック範囲がカードの大きさになるように調整
    - マウスオーバー時リンクの下線が出ないように変更
    - テキスト教材タイトル表示、pタグのclassを整理
    - テキスト教材ジャンル表示、pタグのclassを整理
    - .text-titleのマージンの単位をpxに統一
    - .text-subtitleのマージン単位をpxに統一

## 参考資料
- Bootstrap4 リファレンス
  - [Bootstrap4 日本語リファレンス Cards](https://getbootstrap.jp/docs/4.2/components/card/)
- aタグの下線を消す
  - [【初心者向け】aタグの効果を無効化させる時によく使う系のCSSまとめ](https://qiita.com/7note/items/f3f9a6fd82bb8872c8c3)

## チェックリスト

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
