### PR TITLE
23-2_テキスト教材一覧共通化処理の実装

### DIFF
--- a/app/controllers/texts_controller.rb
+++ b/app/controllers/texts_controller.rb
@@ -1,6 +1,9 @@
 class TextsController < ApplicationController
+  @@BASIC_GENRE = ["Basic", "Git", "Ruby", "Ruby on Rails"]
+
   def index
-    @q = Text.ransack(params[:q])
+    params[:genre] ||= @@BASIC_GENRE
+    @q = Text.where(genre: params[:genre]).ransack(params[:q])
     @texts = @q.result
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
   root to: "texts#index"
 
   resources :movies, only: [:index, :show]
-  resources :texts, only: %i(show) do
+  resources :texts, only: [:index, :show] do
     resource :readed_texts, only: [:create, :destroy]
   end
 end


### PR DESCRIPTION
## 実装内容
- テキスト教材一覧共通化
  - `config/route.rb` の適正化（修正）
    - `127.0.0.1:3000/texts`(root)に接続時、["Basic", "Git", "Ruby", "Ruby on Rails"]のジャンルが表示される。
    - `127.0.0.1:3000/texts?genre=AWS`に接続時、"AWS"のジャンルが表示される。
    - `127.0.0.1:3000/texts?genre=Php`に接続時、"Php"のジャンルが表示される。

## 参考資料
- やんばるCODE教材
  - [モデルの関連付け その2（多対多）](https://arcane-gorge-21903.herokuapp.com/texts/297)
- Qiita
  - [HTTPとPOSTとGET](https://qiita.com/Sekky0905/items/dff3d0da059d6f5bfabf)

## チェックリスト
- [ ] GitHub で Files changed を確認
- [ ] 影響し得る範囲のローカル環境での動作確認

## 備考
