### PR TITLE
35_login画面フォームの崩れ修正

### DIFF
--- a/app/assets/stylesheets/texts.scss
+++ b/app/assets/stylesheets/texts.scss
@@ -45,6 +45,6 @@ div {
   }
 }
 
-form {
+form.text-search {
   width: 350px;
 }

--- a/app/views/texts/index.html.erb
+++ b/app/views/texts/index.html.erb
@@ -2,7 +2,7 @@
   <h1>テキスト教材</h1>
 </div>
 
-<form class="my-3 mx-auto">
+<form class="text-search my-3 mx-auto">
   <%= search_form_for @q, url: root_path do |f| %>
     <%= f.search_field :title_cont, placeholder: "タイトル検索" %>
     <%= f.search_field :genre_cont, placeholder: "ジャンル検索" %>


### PR DESCRIPTION
## 実装内容

- テキスト一覧検索フォームのスタイルを指定
  - `app/views/texts/index.html.erb` 検索フォームに`class=text-search` を設定
  - `app/assets/stylesheets/text/scss`  `form.text-search {width: 350px}` に設定

## 参考資料

- やんばるCODE教材
  - [CSS基礎（その2）](https://arcane-gorge-21903.herokuapp.com/texts/258)

## チェックリスト

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認

## 備考
Login側のスタイルは規定値を使用する為、テキスト教材側のスタイルを修正しました。
