### PR TITLE
34_Rails Best Practice 指摘箇所の修正

### DIFF
--- a/app/models/admin_user.rb
+++ b/app/models/admin_user.rb
@@ -1,6 +1,6 @@
 class AdminUser < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
-  devise :database_authenticatable, 
+  devise :database_authenticatable,
          :recoverable, :rememberable, :validatable
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,4 +1,4 @@
-require_relative 'boot'
+require_relative "boot"
 
 require "rails"
 # Pick the frameworks you want:
@@ -23,9 +23,9 @@ module GyakutenCloneGroup
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.0
-    
+
     config.i18n.default_locale = :ja
-    config.time_zone = 'Asia/Tokyo'
+    config.time_zone = "Asia/Tokyo"
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
 
   root to: "texts#index"
 
-  resources :movies, only: [:index, :show]
+  resources :movies, only: [:index]
   resources :texts, only: [:index, :show] do
     resource :readed_texts, only: [:create, :destroy]
   end


### PR DESCRIPTION
## 実装内容
- Rails Best Practiceで指摘された構文の修正
  - config/routes.rb:8 - restrict auto-generated routes movies (only: [:index])
  - app/models/admin_user.rb:4 - remove trailing whitespace
  - config/application.rb:26 - remove trailing whitespace

## 参考資料
- やんばるCODE教材
  - [Rails Best Practice の導入](https://arcane-gorge-21903.herokuapp.com/texts/215)

## チェックリスト
- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認

## 備考
- シンタックスハイライトは使用する可能性があるので削除しませんでした。
- kaminari で自動生成されたコードは修正しませんでした。
