### PR TITLE
36_テキスト教材カードUIのリンク範囲修正

### DIFF
--- a/app/views/texts/_readed.html.erb
+++ b/app/views/texts/_readed.html.erb
@@ -1,3 +1,3 @@
 <!-- 読破済み（クリックすると読破済みを解除する） -->
-<%= link_to "読破済みを解除", text_readed_texts_path(text_id),
-  method: :delete, remote: true, class: "btn btn-secondary btn-block" %>
+<object><%= link_to "読破済みを解除", text_readed_texts_path(text_id),
+  method: :delete, remote: true, class: "btn btn-secondary btn-block" %></object>

--- a/app/views/texts/_unread.html.erb
+++ b/app/views/texts/_unread.html.erb
@@ -1,3 +1,3 @@
 <!-- 未読（クリックすると読破済みにする） -->
-<%= link_to "読破済みにする", text_readed_texts_path(text_id),
-  method: :post, remote: true, class: "btn btn-primary btn-block" %>
+<object><%= link_to "読破済みにする", text_readed_texts_path(text_id),
+  method: :post, remote: true, class: "btn btn-primary btn-block" %></object>


### PR DESCRIPTION
## 実装内容
- テキスト教材一覧の詳細へのリンク範囲が崩れていたので修正。
  - 読破済みボタンにobjectタグを適用した。

## 参考資料
- [aタグの中にaタグを書きたい時のtips](https://qiita.com/fukamiiiiinmin/items/7412b21c6df5de31cab1)
- [aタグの中でaタグを利用する方法](https://pg.kdtk.net/2028)

## チェックリスト
- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認

